### PR TITLE
Fixed bug with placeholders (double %% after escaping the message)

### DIFF
--- a/pcgf_pluginlib-bukkit/src/at/pcgamingfreaks/Bukkit/Message/Message.java
+++ b/pcgf_pluginlib-bukkit/src/at/pcgamingfreaks/Bukkit/Message/Message.java
@@ -308,13 +308,13 @@ public final class Message extends at.pcgamingfreaks.Message.Message<Message, Pl
 		if(getSendMethod() == SendMethod.DISABLED) return;
 		if(target instanceof Player && getSendMethod() != SendMethod.CHAT_CLASSIC)
 		{
-			String jsonMsg = (args != null && args.length > 0) ? String.format(json, quoteArgs(args)) : json;
+			String jsonMsg = prepareMessage(true, args);
 			if(isPlaceholderApiEnabled()) jsonMsg = PlaceholderAPI.setPlaceholders(playerForPAPI, jsonMsg);
 			sendMethod.getActiveSender().send((Player) target, jsonMsg, optionalParameters);
 		}
 		else
 		{
-			String msg = (args != null && args.length > 0) ? String.format(fallback, args) : fallback;
+			String msg = prepareMessage(false, args);
 			if(isPlaceholderApiEnabled()) msg = PlaceholderAPI.setPlaceholders(playerForPAPI, msg);
 			target.sendMessage(msg);
 		}

--- a/pcgf_pluginlib-common/src/at/pcgamingfreaks/Language.java
+++ b/pcgf_pluginlib-common/src/at/pcgamingfreaks/Language.java
@@ -421,7 +421,7 @@ public class Language extends YamlFileManager
 		T msg = null;
 		try
 		{
-			final String msgString = (escapeStringFormatCharacters) ? getTranslated(path).replaceAll("%", "%%") : getTranslated(path);
+			final String msgString = getTranslated(path);
 			//noinspection unchecked
 			msg = (T) messageClasses.messageConstructor.newInstance(msgString);
 			if(msgString.isEmpty())
@@ -429,6 +429,7 @@ public class Language extends YamlFileManager
 				messageClasses.setSendMethod.invoke(msg, Enum.valueOf(messageClasses.enumType, "DISABLED"));
 				return msg;
 			}
+			if(escapeStringFormatCharacters) msg.escapeStringFormatCharacters();
 			final String pathSendMethod = KEY_LANGUAGE + path + KEY_ADDITION_SEND_METHOD, pathParameter = KEY_LANGUAGE + path + KEY_ADDITION_PARAMETERS;
 			if(yaml.isSet(pathSendMethod))
 			{
@@ -455,14 +456,14 @@ public class Language extends YamlFileManager
 			}
 			if(yaml.getBoolean(KEY_LANGUAGE + path + KEY_ADDITION_PAPI, false))
 			{
-                try
-                {
-                    msg.setPlaceholderApiEnabled(true);
-                }
-                catch(UnsupportedOperationException e)
-                {
-                    logger.warning(ConsoleColor.RED + e.getMessage() + ConsoleColor.RESET);
-                }
+				try
+				{
+					msg.setPlaceholderApiEnabled(true);
+				}
+				catch(UnsupportedOperationException e)
+				{
+					logger.warning(ConsoleColor.RED + e.getMessage() + ConsoleColor.RESET);
+				}
 			}
 		}
 		catch(Exception e)

--- a/pcgf_pluginlib-common/src/at/pcgamingfreaks/Message/Message.java
+++ b/pcgf_pluginlib-common/src/at/pcgamingfreaks/Message/Message.java
@@ -57,6 +57,7 @@ public abstract class Message<MESSAGE extends Message<?,?,?,?>, PLAYER, COMMAND_
 	protected List<MESSAGE_COMPONENT> messageComponents = null;
 	@Getter protected boolean placeholderApiEnabled = false;
 	@Getter private boolean legacy = false;
+	private boolean escaped; // % -> %%
 	//endregion
 
 	//region Constructors
@@ -183,6 +184,15 @@ public abstract class Message<MESSAGE extends Message<?,?,?,?>, PLAYER, COMMAND_
 		return (MESSAGE) this;
 	}
 
+	public void escapeStringFormatCharacters()
+	{
+		if (!escaped)
+		{
+			replaceAll("%", "%%");
+			escaped = true;
+		}
+	}
+
 	protected Object[] quoteArgs(final Object[] args)
 	{
 		for(int i = 0; i < args.length; i++)
@@ -208,8 +218,8 @@ public abstract class Message<MESSAGE extends Message<?,?,?,?>, PLAYER, COMMAND_
 		if(args != null && args.length > 0)
 		{
 			if(useJson) quoteArgs(args);
-			return String.format(msg, args);
+			return String.format(msg, args);  // %% will be converted to % automatically
 		}
-		return msg;
+		return escaped ? msg.replaceAll("%%", "%") : msg; // manually convert %% to %
 	}
 }


### PR DESCRIPTION
Start the discussion here: https://github.com/GeorgH93/MarriageMaster/issues/237

if getMessage(...) escapes percentage to double char (%%), then placeholders does not work.
We need to unescape them back before call to PlaceholderAPI.setPlaceholders(...)

The concepts is that we will remember that message was escaped % to %%.
And the method prepareMessage(...) will unescape it again at the end if it was escaped.

Tested.
No double %% after processing the messages.
Placeholders works finer.